### PR TITLE
Add useAvroLogicalTypes source format option for Avro

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -983,7 +983,7 @@ class BigQueryBaseCursor(LoggingMixin):
             'DATASTORE_BACKUP': ['projectionFields'],
             'NEWLINE_DELIMITED_JSON': ['autodetect', 'ignoreUnknownValues'],
             'PARQUET': ['autodetect', 'ignoreUnknownValues'],
-            'AVRO': [],
+            'AVRO': ['useAvroLogicalTypes'],
         }
         valid_configs = src_fmt_to_configs_mapping[source_format]
         src_fmt_configs = {


### PR DESCRIPTION
See REST schema here https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationload

Minor feature addition, LMK if I should add anything else but seems pretty straightforward.
